### PR TITLE
Add npm plugin for tracking package version releases

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -4,5 +4,6 @@
   "packages/plugin-date": "0.4.2",
   "packages/plugin-figma": "0.4.2",
   "packages/plugin-github": "0.7.2",
+  "packages/plugin-npm": "0.0.0",
   "packages/todone": "1.0.1"
 }

--- a/packages/plugin-npm/docs.md
+++ b/packages/plugin-npm/docs.md
@@ -1,0 +1,35 @@
+# @todone/plugin-npm
+
+A {@link todone} plugin that will alert you when an npm package publishes a version that satisfies a semver range.
+
+## Setup
+
+Call the plugin factory in your `todone.config.ts`:
+
+```ts
+import npmPlugin from "@todone/plugin-npm";
+import { defineConfig } from "todone/config";
+
+export default defineConfig({
+  plugins: [npmPlugin()],
+});
+```
+
+## Options
+
+- `registry`: Base URL of the npm registry to query. Defaults to the `NPM_CONFIG_REGISTRY` environment variable, or the public npm registry (`https://registry.npmjs.org/`).
+
+## Usage
+
+Add a `@TODO` comment with a package specifier in the format `npm:package-name@semver-range`. The TODO expires as soon as any published version of the package satisfies the range:
+
+```js
+// @TODO npm:react@>=20
+// Migrate to the new API once React 20 is released.
+legacyReactApi();
+
+// Scoped packages work too:
+// @TODO npm:@types/node@^26
+```
+
+Any [semver range](https://github.com/npm/node-semver#ranges) works, but it can't contain spaces, since the specifier has to be a valid URL. Prefer space-free forms like `^1.2.3`, `>=2`, or `1.x`; if you really need one with spaces, URL-encode it (e.g. `npm:foo@%3E%3D1.2.3%20%3C2.0.0` for `>=1.2.3 <2.0.0`).

--- a/packages/plugin-npm/package.json
+++ b/packages/plugin-npm/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@todone/plugin-npm",
+  "version": "0.0.0",
+  "type": "module",
+  "description": "A todone plugin that will alert you when an npm package publishes a version that satisfies a range",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/cprecioso/todone.git"
+  },
+  "homepage": "https://github.com/cprecioso/todone/tree/main/packages/plugin-npm#readme",
+  "bugs": {
+    "url": "https://github.com/cprecioso/todone/issues"
+  },
+  "author": "Carlos Precioso <npm@precioso.design>",
+  "license": "ISC",
+  "packageManager": "yarn@4.17.1",
+  "exports": {
+    "types": "./dist/index.d.ts",
+    "default": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsdown",
+    "check": "tsc --noEmit -p .",
+    "dev": "tsdown --watch"
+  },
+  "peerDependencies": {
+    "todone": "workspace:^"
+  },
+  "dependencies": {
+    "semver": "^7.8.4",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@todone/internal-build": "workspace:^",
+    "@types/node": "^24.13.2",
+    "@types/semver": "^7.7.1",
+    "todone": "workspace:^",
+    "tsdown": "^0.22.3",
+    "typescript": "~6.0.3"
+  },
+  "publishConfig": {
+    "provenance": true,
+    "access": "public"
+  },
+  "sideEffects": false
+}

--- a/packages/plugin-npm/readme.md
+++ b/packages/plugin-npm/readme.md
@@ -1,0 +1,1 @@
+Visit the docs at <https://cprecioso.github.io/todone/modules/_todone_plugin-npm.html>

--- a/packages/plugin-npm/src/index.ts
+++ b/packages/plugin-npm/src/index.ts
@@ -1,0 +1,61 @@
+import * as semver from "semver";
+import type { Plugin } from "todone/plugin";
+import * as z from "zod";
+import * as pkg from "../package.json" with { type: "json" };
+import { fetchPackageVersions } from "./lib";
+
+const specPattern = /^(?<name>(?:@[^/@]+\/)?[^/@]+)@(?<range>.+)$/;
+
+const Spec = z.object({
+  name: z.string(),
+  range: z.string(),
+});
+
+export interface NpmPluginOptions {
+  /**
+   * Base URL of the npm registry to query. Defaults to
+   * `process.env.NPM_CONFIG_REGISTRY`, or the public npm registry.
+   */
+  registry?: string | URL;
+}
+
+const npmPlugin = ({
+  registry = process.env.NPM_CONFIG_REGISTRY ?? "https://registry.npmjs.org/",
+}: NpmPluginOptions = {}): Plugin => {
+  // A trailing slash so package names resolve relative to the registry path.
+  const registryUrl = new URL(registry);
+  if (!registryUrl.pathname.endsWith("/")) registryUrl.pathname += "/";
+
+  return {
+    name: pkg.name,
+    checkMatch: async ({ url }) => {
+      if (url.protocol !== "npm:") return null;
+
+      const specMatch = specPattern.exec(decodeURIComponent(url.pathname));
+      if (!specMatch) {
+        throw new Error(
+          `Invalid npm specifier ${url}. Expected \`npm:package-name@semver-range\`.`,
+        );
+      }
+
+      const { name, range } = Spec.parse(specMatch.groups);
+
+      if (semver.validRange(range) == null) {
+        throw new Error(`Invalid semver range \`${range}\` in ${url}`);
+      }
+
+      const versions = await fetchPackageVersions(registryUrl, name);
+      const satisfyingVersion = semver.maxSatisfying(versions, range);
+
+      return {
+        title:
+          satisfyingVersion == null
+            ? `${name}@${range}`
+            : `${name}@${range} (satisfied by v${satisfyingVersion})`,
+        isExpired: satisfyingVersion != null,
+      };
+    },
+  };
+};
+
+export default npmPlugin;

--- a/packages/plugin-npm/src/lib.ts
+++ b/packages/plugin-npm/src/lib.ts
@@ -1,0 +1,35 @@
+import * as z from "zod";
+
+/** @see https://github.com/npm/registry/blob/main/docs/responses/package-metadata.md */
+const Packument = z.object({
+  versions: z.record(z.string(), z.unknown()),
+});
+
+export const fetchPackageVersions = async (
+  registry: URL,
+  name: string,
+): Promise<string[]> => {
+  const url = new URL(name.replace("/", "%2F"), registry);
+
+  const response = await fetch(url, {
+    headers: {
+      // Prefer the abbreviated packument, which is much smaller than the full
+      // one, but still lists every published version.
+      accept:
+        "application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8",
+    },
+  });
+
+  if (response.status === 404) {
+    throw new Error(`Package \`${name}\` not found in registry ${registry}`);
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `Registry request for \`${name}\` failed: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const packument = Packument.parse(await response.json());
+  return Object.keys(packument.versions);
+};

--- a/packages/plugin-npm/tsconfig.json
+++ b/packages/plugin-npm/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@todone/internal-build/tsconfig",
+  "include": ["src/**/*", "types/**/*"]
+}

--- a/packages/plugin-npm/tsdown.config.ts
+++ b/packages/plugin-npm/tsdown.config.ts
@@ -1,0 +1,3 @@
+import { defaultConfig } from "@todone/internal-build/tsdown";
+
+export default defaultConfig();

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -24,6 +24,7 @@
     "@todone/plugin-date": "workspace:^",
     "@todone/plugin-figma": "workspace:^",
     "@todone/plugin-github": "workspace:^",
+    "@todone/plugin-npm": "workspace:^",
     "@types/node": "^24.13.2",
     "todone": "workspace:^"
   },

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -14,6 +14,7 @@
     "packages/plugin-date": {},
     "packages/plugin-figma": {},
     "packages/plugin-github": {},
+    "packages/plugin-npm": {},
     "packages/todone": {}
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -852,6 +852,23 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@todone/plugin-npm@workspace:^, @todone/plugin-npm@workspace:packages/plugin-npm":
+  version: 0.0.0-use.local
+  resolution: "@todone/plugin-npm@workspace:packages/plugin-npm"
+  dependencies:
+    "@todone/internal-build": "workspace:^"
+    "@types/node": "npm:^24.13.2"
+    "@types/semver": "npm:^7.7.1"
+    semver: "npm:^7.8.4"
+    todone: "workspace:^"
+    tsdown: "npm:^0.22.3"
+    typescript: "npm:~6.0.3"
+    zod: "npm:^4.4.3"
+  peerDependencies:
+    todone: "workspace:^"
+  languageName: unknown
+  linkType: soft
+
 "@todone/repo@workspace:.":
   version: 0.0.0-use.local
   resolution: "@todone/repo@workspace:."
@@ -882,6 +899,7 @@ __metadata:
     "@todone/plugin-date": "workspace:^"
     "@todone/plugin-figma": "workspace:^"
     "@todone/plugin-github": "workspace:^"
+    "@todone/plugin-npm": "workspace:^"
     "@types/node": "npm:^24.13.2"
     todone: "workspace:^"
   languageName: unknown
@@ -948,6 +966,13 @@ __metadata:
   dependencies:
     undici-types: "npm:~7.18.0"
   checksum: 10/2b8cb95ada191ecc788fef91d7cdb86dff24f6895b510e1fb495cc001832709fa8fc3e1eeb27d64bda52b3f74f9e91acf42431e98e3e6876de1e53acce7f7602
+  languageName: node
+  linkType: hard
+
+"@types/semver@npm:^7.7.1":
+  version: 7.7.1
+  resolution: "@types/semver@npm:7.7.1"
+  checksum: 10/8f09e7e6ca3ded67d78ba7a8f7535c8d9cf8ced83c52e7f3ac3c281fe8c689c3fe475d199d94390dc04fc681d51f2358b430bb7b2e21c62de24f2bee2c719068
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
This PR introduces a new `@todone/plugin-npm` plugin that allows users to track npm package releases and automatically expire TODOs when a package version satisfying a specified semver range is published.

## Key Changes
- **New plugin package** (`packages/plugin-npm`): Implements npm registry integration for the todone system
  - `src/index.ts`: Main plugin factory that parses `npm:package-name@semver-range` URLs and checks npm registry for satisfying versions
  - `src/lib.ts`: Registry client that fetches package metadata from npm (with support for custom registries via `NPM_CONFIG_REGISTRY`)
  - Comprehensive documentation in `docs.md` with setup instructions and usage examples
  
- **Plugin Features**:
  - Parses npm specifiers in the format `npm:package-name@semver-range` (supports scoped packages)
  - Queries the npm registry to fetch all published versions
  - Uses semver to find the maximum version satisfying the specified range
  - Marks TODOs as expired when a satisfying version is found
  - Supports custom npm registries via environment variable or configuration option
  - Validates semver ranges and provides helpful error messages

- **Integration**: Added the new plugin to the test app and release configuration

## Notable Implementation Details
- Uses the npm registry's abbreviated packument format for efficient version fetching
- Properly handles URL encoding for scoped package names (`@scope/name`)
- Validates input using Zod schemas for type safety
- Supports both public npm registry and private registries via configurable base URL
- Follows the existing todone plugin architecture and patterns

https://claude.ai/code/session_01WcyMhqwy1JQM4K89ks1tnB