### PR TITLE
Add Forgejo plugin for checking issues, PRs, and milestones

### DIFF
--- a/packages/plugin-forgejo/docs.md
+++ b/packages/plugin-forgejo/docs.md
@@ -1,0 +1,44 @@
+# @todone/plugin-forgejo
+
+A {@link todone} plugin that will alert you when a Forgejo issue or pull request has been resolved. Works with any Forgejo instance ([Codeberg](https://codeberg.org) by default), and should also work with Gitea instances, since they share the same API.
+
+## Setup
+
+Call the plugin factory in your `todone.config.ts`:
+
+```ts
+import forgejoPlugin from "@todone/plugin-forgejo";
+import { defineConfig } from "todone/config";
+
+export default defineConfig({
+  plugins: [forgejoPlugin()],
+});
+```
+
+## Options
+
+- `instances`: The base URLs of the Forgejo instances whose links should be checked. Defaults to `["https://codeberg.org"]`. Add your own instance here if you self-host, including instances hosted under a subpath:
+
+  ```ts
+  forgejoPlugin({
+    instances: ["https://codeberg.org", "https://git.example.com/forgejo"],
+  });
+  ```
+
+- `token`: The Forgejo API token to use for authentication. You can generate an access token from your instance's user settings, under Applications. Defaults to the `FORGEJO_TOKEN` environment variable.
+
+  Without a token, the plugin still works for public repositories (subject to the instance's unauthenticated rate limits) and emits a warning when created. Checking a URL that requires authentication (e.g. a private repository) without a token fails with an error explaining that a token may be required.
+
+  Note that the same token is sent to every configured instance, so if you use several instances with private repositories, prefer configuring one plugin per instance, each with its own token.
+
+## Usage
+
+Add a `@TODO` comment with a link to a Forgejo issue, pull request, or milestone:
+
+```js
+/*
+  @TODO https://codeberg.org/org/repo/issues/42
+  Remove workaround once upstream issue is resolved.
+*/
+setTimeout(() => processQueue(), 0);
+```

--- a/packages/plugin-forgejo/package.json
+++ b/packages/plugin-forgejo/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@todone/plugin-forgejo",
+  "version": "0.0.0",
+  "type": "module",
+  "description": "A todone plugin that will alert you when a Forgejo issue or pull request has been resolved",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/cprecioso/todone.git"
+  },
+  "homepage": "https://github.com/cprecioso/todone/tree/main/packages/plugin-forgejo#readme",
+  "bugs": {
+    "url": "https://github.com/cprecioso/todone/issues"
+  },
+  "author": "Carlos Precioso <npm@precioso.design>",
+  "license": "ISC",
+  "packageManager": "yarn@4.17.1",
+  "exports": {
+    "types": "./dist/index.d.ts",
+    "default": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsdown",
+    "check": "tsc --noEmit -p .",
+    "dev": "tsdown --watch"
+  },
+  "peerDependencies": {
+    "todone": "workspace:^"
+  },
+  "dependencies": {
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@todone/internal-build": "workspace:^",
+    "todone": "workspace:^",
+    "tsdown": "^0.22.3",
+    "typescript": "~6.0.3"
+  },
+  "publishConfig": {
+    "provenance": true,
+    "access": "public"
+  },
+  "sideEffects": false
+}

--- a/packages/plugin-forgejo/readme.md
+++ b/packages/plugin-forgejo/readme.md
@@ -1,0 +1,1 @@
+Visit the docs at <https://cprecioso.github.io/todone/modules/_todone_plugin-forgejo.html>

--- a/packages/plugin-forgejo/src/api.ts
+++ b/packages/plugin-forgejo/src/api.ts
@@ -1,0 +1,85 @@
+import { CheckerResult } from "todone/plugin";
+import * as z from "zod";
+
+const maybeDate = (date: string | null | undefined): Date | undefined =>
+  (date && new Date(date)) || undefined;
+
+const Issue = z.object({
+  title: z.string(),
+  state: z.string(),
+  closed_at: z.string().nullish(),
+});
+
+const Milestone = z.object({
+  title: z.string(),
+  state: z.string(),
+  closed_at: z.string().nullish(),
+  due_on: z.string().nullish(),
+});
+
+export const makeResourceFetchers = (token?: string) => {
+  const apiRequest = async (instance: URL, path: string): Promise<unknown> => {
+    const response = await fetch(new URL(`api/v1/${path}`, instance), {
+      headers: {
+        accept: "application/json",
+        ...(token ? { authorization: `token ${token}` } : null),
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `Forgejo API request failed (${response.status} ${response.statusText}): ${response.url}`,
+      );
+    }
+
+    return await response.json();
+  };
+
+  return {
+    issues: async (instance, { owner, repo }, number) => {
+      const data = Issue.parse(
+        await apiRequest(instance, `repos/${owner}/${repo}/issues/${number}`),
+      );
+
+      return {
+        title: data.title,
+        isExpired: data.state === "closed",
+        expirationDate: maybeDate(data.closed_at),
+      };
+    },
+
+    pulls: async (instance, { owner, repo }, number) => {
+      const data = Issue.parse(
+        await apiRequest(instance, `repos/${owner}/${repo}/pulls/${number}`),
+      );
+
+      return {
+        title: data.title,
+        isExpired: data.state === "closed",
+        expirationDate: maybeDate(data.closed_at),
+      };
+    },
+
+    milestone: async (instance, { owner, repo }, number) => {
+      const data = Milestone.parse(
+        await apiRequest(
+          instance,
+          `repos/${owner}/${repo}/milestones/${number}`,
+        ),
+      );
+
+      return {
+        title: data.title,
+        isExpired: data.state === "closed",
+        expirationDate: maybeDate(data.closed_at) || maybeDate(data.due_on),
+      };
+    },
+  } as const satisfies Record<
+    string,
+    (
+      instance: URL,
+      repo: { owner: string; repo: string },
+      number: number,
+    ) => Promise<CheckerResult>
+  >;
+};

--- a/packages/plugin-forgejo/src/index.ts
+++ b/packages/plugin-forgejo/src/index.ts
@@ -1,0 +1,95 @@
+import type { Plugin } from "todone/plugin";
+import * as z from "zod";
+import * as pkg from "../package.json" with { type: "json" };
+import { makeResourceFetchers } from "./api";
+
+const DEFAULT_INSTANCES = ["https://codeberg.org"];
+
+const makeInstancePattern = (instance: URL) =>
+  new URLPattern({
+    protocol: instance.protocol.slice(0, -1),
+    hostname: instance.hostname,
+    port: instance.port,
+    pathname: `${instance.pathname.replace(/\/$/, "")}/:owner/:repo/:resource_kind(issues|pulls|milestone)/:number`,
+  });
+
+const PatternResult = z.object({
+  pathname: z.object({
+    groups: z.object({
+      owner: z.string(),
+      repo: z.string(),
+      resource_kind: z.enum(["issues", "pulls", "milestone"]),
+      number: z.coerce.number().int().positive(),
+    }),
+  }),
+});
+
+export interface ForgejoPluginOptions {
+  /**
+   * Base URLs of the Forgejo instances whose links should be checked.
+   * Defaults to `["https://codeberg.org"]`. Instances hosted under a subpath
+   * (e.g. `https://example.com/forgejo`) are supported.
+   */
+  instances?: readonly (string | URL)[];
+
+  /** Forgejo API token. Defaults to `process.env.FORGEJO_TOKEN`. */
+  token?: string;
+}
+
+const forgejoPlugin = ({
+  instances = DEFAULT_INSTANCES,
+  token = process.env.FORGEJO_TOKEN,
+}: ForgejoPluginOptions = {}): Plugin => {
+  if (!token) {
+    process.emitWarning(
+      "No Forgejo token provided (`token` option or FORGEJO_TOKEN env var). " +
+        "Public repositories will still work, but private repositories and " +
+        "higher rate limits require a token.",
+      { code: "TODONE_FORGEJO_NO_TOKEN" },
+    );
+  }
+
+  const instanceMatchers = instances.map((instance) => {
+    const instanceURL = new URL(instance);
+    // A trailing slash makes the URL usable as a base for API paths
+    if (!instanceURL.pathname.endsWith("/")) instanceURL.pathname += "/";
+    return { instanceURL, pattern: makeInstancePattern(instanceURL) };
+  });
+
+  const resourceFetchers = makeResourceFetchers(token);
+
+  return {
+    name: pkg.name,
+    checkMatch: async ({ url }) => {
+      for (const { instanceURL, pattern } of instanceMatchers) {
+        const patternResult = pattern.exec(url);
+        if (!patternResult) continue;
+
+        const {
+          pathname: {
+            groups: { owner, repo, resource_kind, number },
+          },
+        } = PatternResult.parse(patternResult);
+
+        try {
+          return await resourceFetchers[resource_kind](
+            instanceURL,
+            { owner, repo },
+            number,
+          );
+        } catch (error) {
+          if (token) throw error;
+          throw new Error(
+            `Forgejo request for ${url} failed without authentication. ` +
+              `This URL may require a FORGEJO_TOKEN (private repository or rate limit).`,
+            { cause: error },
+          );
+        }
+      }
+
+      return null;
+    },
+  };
+};
+
+export default forgejoPlugin;

--- a/packages/plugin-forgejo/tsconfig.json
+++ b/packages/plugin-forgejo/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@todone/internal-build/tsconfig",
+  "include": ["src/**/*", "types/**/*"]
+}

--- a/packages/plugin-forgejo/tsdown.config.ts
+++ b/packages/plugin-forgejo/tsdown.config.ts
@@ -1,0 +1,3 @@
+import { defaultConfig } from "@todone/internal-build/tsdown";
+
+export default defaultConfig();

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -13,6 +13,7 @@
     "packages/plugin-caniuse": {},
     "packages/plugin-date": {},
     "packages/plugin-figma": {},
+    "packages/plugin-forgejo": {},
     "packages/plugin-github": {},
     "packages/todone": {}
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -837,6 +837,20 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@todone/plugin-forgejo@workspace:packages/plugin-forgejo":
+  version: 0.0.0-use.local
+  resolution: "@todone/plugin-forgejo@workspace:packages/plugin-forgejo"
+  dependencies:
+    "@todone/internal-build": "workspace:^"
+    todone: "workspace:^"
+    tsdown: "npm:^0.22.3"
+    typescript: "npm:~6.0.3"
+    zod: "npm:^4.4.3"
+  peerDependencies:
+    todone: "workspace:^"
+  languageName: unknown
+  linkType: soft
+
 "@todone/plugin-github@workspace:^, @todone/plugin-github@workspace:packages/plugin-github":
   version: 0.0.0-use.local
   resolution: "@todone/plugin-github@workspace:packages/plugin-github"


### PR DESCRIPTION
## Summary

This PR introduces a new `@todone/plugin-forgejo` plugin that enables todone to check the status of Forgejo issues, pull requests, and milestones. The plugin works with any Forgejo instance (defaulting to Codeberg) and should also be compatible with Gitea instances due to their shared API.

## Key Changes

- **New plugin package** (`packages/plugin-forgejo/`) with full implementation:
  - `index.ts`: Main plugin factory that matches Forgejo URLs and delegates to resource fetchers
  - `api.ts`: API client implementation for fetching issue, PR, and milestone data from Forgejo instances
  - Comprehensive documentation and configuration examples

- **URL pattern matching**: Uses `URLPattern` API to match Forgejo links across configurable instances, supporting both root-hosted and subpath-hosted instances

- **Resource fetching**: Implements fetchers for three resource types:
  - Issues: Returns title, closed state, and closure date
  - Pull requests: Same schema as issues
  - Milestones: Returns title, closed state, and expiration date (closure or due date)

- **Authentication support**: Optional API token support via `token` option or `FORGEJO_TOKEN` environment variable, with graceful degradation for public repositories and helpful error messages for private ones

- **Configuration**: Flexible options for multiple Forgejo instances and authentication tokens

- **Release configuration**: Added plugin to `release-please-config.json` for automated versioning

## Notable Implementation Details

- Uses Zod for runtime validation of API responses
- Emits a warning (not an error) when no token is provided, allowing public repository access
- Provides context-aware error messages distinguishing between authentication failures and other API errors
- Supports instances with custom base paths (e.g., `https://example.com/forgejo`)

https://claude.ai/code/session_01DoENxEX6XNKmup6QNzgBgC