### PR TITLE
Add Jira plugin for tracking issue resolution

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -4,5 +4,6 @@
   "packages/plugin-date": "0.4.2",
   "packages/plugin-figma": "0.4.2",
   "packages/plugin-github": "0.7.2",
+  "packages/plugin-jira": "0.1.0",
   "packages/todone": "1.0.1"
 }

--- a/packages/plugin-jira/docs.md
+++ b/packages/plugin-jira/docs.md
@@ -1,0 +1,40 @@
+# @todone/plugin-jira
+
+A {@link todone} plugin that will alert you when a Jira issue has been resolved.
+
+## Setup
+
+Call the plugin factory in your `todone.config.ts`:
+
+```ts
+import jiraPlugin from "@todone/plugin-jira";
+import { defineConfig } from "todone/config";
+
+export default defineConfig({
+  plugins: [jiraPlugin()],
+});
+```
+
+## Options
+
+- `token`: The Jira token to use for authentication. For Jira Cloud, create an API token from your Atlassian account settings; for Jira Server/Data Center, create a personal access token. Defaults to the `JIRA_API_TOKEN` environment variable.
+
+  Without a token, the plugin still works for publicly accessible issues and emits a warning when created. Checking a URL that requires authentication without a token fails with an error explaining that a token may be required.
+
+- `email`: The email of the Jira account the token belongs to. Required for Jira Cloud API tokens (which use Basic authentication); leave empty for Jira Server/Data Center personal access tokens (which use Bearer authentication). Defaults to the `JIRA_EMAIL` environment variable.
+
+- `instanceUrls`: Additional Jira instance URLs to match, for Jira Server/Data Center or other custom domains. URLs on `*.atlassian.net` are always matched. Defaults to the `JIRA_INSTANCE_URL` environment variable (a single URL) if set.
+
+## Usage
+
+Add a `@TODO` comment with a link to a Jira issue:
+
+```js
+/*
+  @TODO https://yourcompany.atlassian.net/browse/PROJ-123
+  Remove this workaround once the migration ticket is done.
+*/
+legacyProcessQueue();
+```
+
+An issue counts as expired once its status is in the "Done" status category (e.g. Done, Closed, Resolved), with the issue's resolution date as the expiration date.

--- a/packages/plugin-jira/package.json
+++ b/packages/plugin-jira/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@todone/plugin-jira",
+  "version": "0.1.0",
+  "type": "module",
+  "description": "A todone plugin that will alert you when a Jira issue has been resolved",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/cprecioso/todone.git"
+  },
+  "homepage": "https://github.com/cprecioso/todone/tree/main/packages/plugin-jira#readme",
+  "bugs": {
+    "url": "https://github.com/cprecioso/todone/issues"
+  },
+  "author": "Carlos Precioso <npm@precioso.design>",
+  "license": "ISC",
+  "packageManager": "yarn@4.17.1",
+  "exports": {
+    "types": "./dist/index.d.ts",
+    "default": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsdown",
+    "check": "tsc --noEmit -p .",
+    "dev": "tsdown --watch"
+  },
+  "peerDependencies": {
+    "todone": "workspace:^"
+  },
+  "dependencies": {
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@todone/internal-build": "workspace:^",
+    "@types/node": "^24.13.2",
+    "todone": "workspace:^",
+    "tsdown": "^0.22.3",
+    "typescript": "~6.0.3"
+  },
+  "publishConfig": {
+    "provenance": true,
+    "access": "public"
+  },
+  "sideEffects": false
+}

--- a/packages/plugin-jira/readme.md
+++ b/packages/plugin-jira/readme.md
@@ -1,0 +1,1 @@
+Visit the docs at <https://cprecioso.github.io/todone/modules/_todone_plugin-jira.html>

--- a/packages/plugin-jira/src/api.ts
+++ b/packages/plugin-jira/src/api.ts
@@ -1,0 +1,59 @@
+import { CheckerResult } from "todone/plugin";
+import * as z from "zod";
+
+const IssueResponse = z.object({
+  fields: z.object({
+    summary: z.string(),
+    status: z.object({
+      statusCategory: z.object({
+        key: z.string(),
+      }),
+    }),
+    resolutiondate: z.coerce.date().nullish(),
+  }),
+});
+
+export interface JiraCredentials {
+  email?: string;
+  token?: string;
+}
+
+const makeHeaders = ({ email, token }: JiraCredentials): HeadersInit => {
+  if (!token) return {};
+  // Jira Cloud API tokens use Basic auth with the account email; Jira
+  // Server/Data Center personal access tokens use Bearer auth.
+  if (email) {
+    const credentials = Buffer.from(`${email}:${token}`).toString("base64");
+    return { Authorization: `Basic ${credentials}` };
+  }
+  return { Authorization: `Bearer ${token}` };
+};
+
+export const createJiraApi = (credentials: JiraCredentials) => {
+  const headers = makeHeaders(credentials);
+
+  return {
+    getIssue: async (origin: string, key: string): Promise<CheckerResult> => {
+      // `/rest/api/2` is available on both Jira Cloud and Jira Server/Data
+      // Center, unlike `/rest/api/3` which is Cloud-only.
+      const response = await fetch(
+        `${origin}/rest/api/2/issue/${encodeURIComponent(key)}?fields=summary,status,resolutiondate`,
+        { headers },
+      );
+
+      if (!response.ok) {
+        throw new Error(
+          `Jira API request failed: ${response.status} ${response.statusText}`,
+        );
+      }
+
+      const { fields } = IssueResponse.parse(await response.json());
+
+      return {
+        title: fields.summary,
+        isExpired: fields.status.statusCategory.key === "done",
+        expirationDate: fields.resolutiondate ?? undefined,
+      };
+    },
+  };
+};

--- a/packages/plugin-jira/src/index.ts
+++ b/packages/plugin-jira/src/index.ts
@@ -1,0 +1,103 @@
+import type { Plugin } from "todone/plugin";
+import * as z from "zod";
+import * as pkg from "../package.json" with { type: "json" };
+import { createJiraApi } from "./api";
+
+const issuePathname = "/browse/:key([A-Z][A-Z0-9_]*-[0-9]+)";
+
+const cloudPattern = new URLPattern({
+  protocol: "http{s}?",
+  hostname: "{*.}?atlassian.net",
+  pathname: issuePathname,
+});
+
+const PatternResult = z.object({
+  pathname: z.object({
+    groups: z.object({
+      key: z.string(),
+    }),
+  }),
+});
+
+export interface JiraPluginOptions {
+  /**
+   * Email of the Jira account to authenticate as. Required for Jira Cloud API
+   * tokens (Basic auth); leave empty for Jira Server/Data Center personal
+   * access tokens (Bearer auth). Defaults to `process.env.JIRA_EMAIL`.
+   */
+  email?: string;
+
+  /**
+   * Jira Cloud API token or Jira Server/Data Center personal access token.
+   * Defaults to `process.env.JIRA_API_TOKEN`.
+   */
+  token?: string;
+
+  /**
+   * Additional Jira instance URLs to match, for Jira Server/Data Center or
+   * other custom domains. `*.atlassian.net` URLs are always matched. Defaults
+   * to `process.env.JIRA_INSTANCE_URL` (a single URL) if set.
+   */
+  instanceUrls?: string[];
+}
+
+const jiraPlugin = ({
+  email = process.env.JIRA_EMAIL,
+  token = process.env.JIRA_API_TOKEN,
+  instanceUrls = process.env.JIRA_INSTANCE_URL
+    ? [process.env.JIRA_INSTANCE_URL]
+    : [],
+}: JiraPluginOptions = {}): Plugin => {
+  if (!token) {
+    process.emitWarning(
+      "No Jira token provided (`token` option or JIRA_API_TOKEN env var). " +
+        "Publicly accessible issues will still work, but most Jira instances " +
+        "require authentication.",
+      { code: "TODONE_JIRA_NO_TOKEN" },
+    );
+  }
+
+  const patterns = [
+    cloudPattern,
+    ...instanceUrls.map((instanceUrl) => {
+      const { protocol, hostname, port } = new URL(instanceUrl);
+      return new URLPattern({
+        protocol: protocol.slice(0, -1),
+        hostname,
+        port,
+        pathname: issuePathname,
+      });
+    }),
+  ];
+
+  const api = createJiraApi({ email, token });
+
+  return {
+    name: pkg.name,
+    checkMatch: async ({ url }) => {
+      const patternResult = patterns
+        .map((pattern) => pattern.exec(url))
+        .find(Boolean);
+      if (!patternResult) return null;
+
+      const {
+        pathname: {
+          groups: { key },
+        },
+      } = PatternResult.parse(patternResult);
+
+      try {
+        return await api.getIssue(url.origin, key);
+      } catch (error) {
+        if (token) throw error;
+        throw new Error(
+          `Jira request for ${url} failed without authentication. ` +
+            `Set the \`token\` option or the JIRA_API_TOKEN environment variable.`,
+          { cause: error },
+        );
+      }
+    },
+  };
+};
+
+export default jiraPlugin;

--- a/packages/plugin-jira/tsconfig.json
+++ b/packages/plugin-jira/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@todone/internal-build/tsconfig",
+  "include": ["src/**/*", "types/**/*"]
+}

--- a/packages/plugin-jira/tsdown.config.ts
+++ b/packages/plugin-jira/tsdown.config.ts
@@ -1,0 +1,3 @@
+import { defaultConfig } from "@todone/internal-build/tsdown";
+
+export default defaultConfig();

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -24,6 +24,7 @@
     "@todone/plugin-date": "workspace:^",
     "@todone/plugin-figma": "workspace:^",
     "@todone/plugin-github": "workspace:^",
+    "@todone/plugin-jira": "workspace:^",
     "@types/node": "^24.13.2",
     "todone": "workspace:^"
   },

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -14,6 +14,7 @@
     "packages/plugin-date": {},
     "packages/plugin-figma": {},
     "packages/plugin-github": {},
+    "packages/plugin-jira": {},
     "packages/todone": {}
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -852,6 +852,21 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@todone/plugin-jira@workspace:^, @todone/plugin-jira@workspace:packages/plugin-jira":
+  version: 0.0.0-use.local
+  resolution: "@todone/plugin-jira@workspace:packages/plugin-jira"
+  dependencies:
+    "@todone/internal-build": "workspace:^"
+    "@types/node": "npm:^24.13.2"
+    todone: "workspace:^"
+    tsdown: "npm:^0.22.3"
+    typescript: "npm:~6.0.3"
+    zod: "npm:^4.4.3"
+  peerDependencies:
+    todone: "workspace:^"
+  languageName: unknown
+  linkType: soft
+
 "@todone/repo@workspace:.":
   version: 0.0.0-use.local
   resolution: "@todone/repo@workspace:."
@@ -882,6 +897,7 @@ __metadata:
     "@todone/plugin-date": "workspace:^"
     "@todone/plugin-figma": "workspace:^"
     "@todone/plugin-github": "workspace:^"
+    "@todone/plugin-jira": "workspace:^"
     "@types/node": "npm:^24.13.2"
     todone: "workspace:^"
   languageName: unknown


### PR DESCRIPTION
## Summary
This PR introduces a new `@todone/plugin-jira` plugin that enables tracking of Jira issues within todone. The plugin monitors Jira issue URLs and alerts when issues transition to a "Done" status.

## Key Changes
- **New Jira Plugin Package**: Created `packages/plugin-jira` with full implementation
  - `src/index.ts`: Main plugin factory that handles URL pattern matching for Jira Cloud (`*.atlassian.net`) and custom Jira Server/Data Center instances
  - `src/api.ts`: Jira API client using the REST API v2 endpoint, supporting both Jira Cloud (Basic auth with email + token) and Jira Server/Data Center (Bearer token auth)
  - Comprehensive configuration options via `JiraPluginOptions` interface with environment variable fallbacks (`JIRA_EMAIL`, `JIRA_API_TOKEN`, `JIRA_INSTANCE_URL`)

- **Plugin Features**:
  - URL pattern matching using URLPattern API for Jira issue browse links
  - Fetches issue details (summary, status, resolution date) from Jira API
  - Marks issues as expired when status category is "done"
  - Graceful handling of unauthenticated requests with helpful error messages
  - Warning emission when no token is provided but plugin is initialized

- **Documentation & Configuration**:
  - Added `docs.md` with setup instructions, options documentation, and usage examples
  - Added `readme.md` pointing to full documentation
  - Configured TypeScript, build tooling, and package exports
  - Integrated into test app and release-please configuration

## Notable Implementation Details
- Uses Zod for runtime validation of Jira API responses
- Supports both Jira Cloud API tokens (Basic auth) and Jira Server/Data Center personal access tokens (Bearer auth)
- REST API v2 endpoint chosen for compatibility across all Jira deployment types
- URLPattern API used for flexible URL matching across different Jira instance domains

https://claude.ai/code/session_01Q6f6SzVEhDcQDZQRDoj6gy