### PR TITLE
Add Linear plugin for todone

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -4,5 +4,6 @@
   "packages/plugin-date": "0.4.2",
   "packages/plugin-figma": "0.4.2",
   "packages/plugin-github": "0.7.2",
+  "packages/plugin-linear": "0.0.0",
   "packages/todone": "1.0.1"
 }

--- a/packages/plugin-linear/docs.md
+++ b/packages/plugin-linear/docs.md
@@ -1,0 +1,36 @@
+# @todone/plugin-linear
+
+A {@link todone} plugin that will alert you when a Linear issue has been completed or canceled.
+
+## Setup
+
+Call the plugin factory in your `todone.config.ts`:
+
+```ts
+import linearPlugin from "@todone/plugin-linear";
+import { defineConfig } from "todone/config";
+
+export default defineConfig({
+  plugins: [linearPlugin()],
+});
+```
+
+## Options
+
+- `apiKey`: The Linear API key to use for authentication. You can generate a personal API key from your Linear account's security settings. Defaults to the `LINEAR_API_KEY` environment variable.
+
+The Linear API always requires authentication: without an API key the plugin emits a warning when created, and checking any Linear URL fails with an error.
+
+## Usage
+
+Add a `@TODO` comment with a link to a Linear issue:
+
+```js
+/*
+  @TODO https://linear.app/my-company/issue/ENG-123/fix-flaky-login
+  Remove this workaround once the login flow is fixed.
+*/
+await retry(() => login(), { attempts: 3 });
+```
+
+The TODO is considered expired once the issue reaches a `completed` or `canceled` state.

--- a/packages/plugin-linear/package.json
+++ b/packages/plugin-linear/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@todone/plugin-linear",
+  "version": "0.0.0",
+  "type": "module",
+  "description": "A todone plugin that will alert you when a Linear issue has been completed or canceled",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/cprecioso/todone.git"
+  },
+  "homepage": "https://github.com/cprecioso/todone/tree/main/packages/plugin-linear#readme",
+  "bugs": {
+    "url": "https://github.com/cprecioso/todone/issues"
+  },
+  "author": "Carlos Precioso <npm@precioso.design>",
+  "license": "ISC",
+  "packageManager": "yarn@4.17.1",
+  "exports": {
+    "types": "./dist/index.d.ts",
+    "default": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsdown",
+    "check": "tsc --noEmit -p .",
+    "dev": "tsdown --watch"
+  },
+  "peerDependencies": {
+    "todone": "workspace:^"
+  },
+  "dependencies": {
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@todone/internal-build": "workspace:^",
+    "@types/node": "^24.13.2",
+    "todone": "workspace:^",
+    "tsdown": "^0.22.3",
+    "typescript": "~6.0.3"
+  },
+  "publishConfig": {
+    "provenance": true,
+    "access": "public"
+  },
+  "sideEffects": false
+}

--- a/packages/plugin-linear/readme.md
+++ b/packages/plugin-linear/readme.md
@@ -1,0 +1,1 @@
+Visit the docs at <https://cprecioso.github.io/todone/modules/_todone_plugin-linear.html>

--- a/packages/plugin-linear/src/api.ts
+++ b/packages/plugin-linear/src/api.ts
@@ -1,0 +1,77 @@
+import * as z from "zod";
+
+const StateType = z.enum([
+  "triage",
+  "backlog",
+  "unstarted",
+  "started",
+  "completed",
+  "canceled",
+]);
+
+const IssueResponse = z.object({
+  data: z
+    .object({
+      issue: z
+        .object({
+          title: z.string(),
+          completedAt: z.coerce.date().nullable(),
+          canceledAt: z.coerce.date().nullable(),
+          state: z.object({ type: StateType }),
+        })
+        .nullable(),
+    })
+    .nullish(),
+  errors: z.array(z.object({ message: z.string() })).optional(),
+});
+
+const API_URL = "https://api.linear.app/graphql";
+
+// The `issue` query accepts both an issue's UUID and its human-readable
+// identifier (e.g. `ENG-123`)
+const ISSUE_QUERY = /* GraphQL */ `
+  query IssueStatus($id: String!) {
+    issue(id: $id) {
+      title
+      completedAt
+      canceledAt
+      state {
+        type
+      }
+    }
+  }
+`;
+
+export const createLinearApi = (apiKey: string) => ({
+  getIssue: async (issueID: string) => {
+    const response = await fetch(API_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: apiKey,
+      },
+      body: JSON.stringify({ query: ISSUE_QUERY, variables: { id: issueID } }),
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `Linear API request failed: ${response.status} ${response.statusText}`,
+      );
+    }
+
+    const result = IssueResponse.parse(await response.json());
+
+    if (result.errors?.length) {
+      throw new Error(
+        `Linear API request failed: ${result.errors
+          .map((error) => error.message)
+          .join("; ")}`,
+      );
+    }
+
+    const issue = result.data?.issue;
+    if (!issue) throw new Error("Issue not found: " + issueID);
+
+    return issue;
+  },
+});

--- a/packages/plugin-linear/src/index.ts
+++ b/packages/plugin-linear/src/index.ts
@@ -1,0 +1,71 @@
+import type { Plugin } from "todone/plugin";
+import * as z from "zod";
+import * as pkg from "../package.json" with { type: "json" };
+import { createLinearApi } from "./api";
+
+const pattern = new URLPattern({
+  protocol: "http{s}?",
+  hostname: "linear.app",
+  pathname: "/:workspace/issue/:issueID([A-Za-z0-9]+-[0-9]+)/:slug?",
+});
+
+const PatternResult = z.object({
+  pathname: z.object({
+    groups: z.object({
+      issueID: z.string(),
+    }),
+  }),
+});
+
+export interface LinearPluginOptions {
+  /** Linear API key. Defaults to `process.env.LINEAR_API_KEY`. */
+  apiKey?: string;
+}
+
+const linearPlugin = ({
+  apiKey = process.env.LINEAR_API_KEY,
+}: LinearPluginOptions = {}): Plugin => {
+  if (!apiKey) {
+    process.emitWarning(
+      "No Linear API key provided (`apiKey` option or LINEAR_API_KEY env var). " +
+        "Any Linear URL check will fail.",
+      { code: "TODONE_LINEAR_NO_API_KEY" },
+    );
+  }
+
+  return {
+    name: pkg.name,
+    checkMatch: async ({ url }) => {
+      const patternResult = pattern.exec(url);
+      if (!patternResult) return null;
+
+      if (!apiKey) {
+        throw new Error(
+          `A Linear API key is required to check ${url}. ` +
+            `Set the \`apiKey\` option or the LINEAR_API_KEY environment variable.`,
+        );
+      }
+
+      const api = createLinearApi(apiKey);
+
+      const {
+        pathname: {
+          groups: { issueID },
+        },
+      } = PatternResult.parse(patternResult);
+
+      const issue = await api.getIssue(issueID);
+
+      const isExpired =
+        issue.state.type === "completed" || issue.state.type === "canceled";
+
+      return {
+        title: issue.title,
+        isExpired,
+        expirationDate: issue.completedAt ?? issue.canceledAt ?? undefined,
+      };
+    },
+  };
+};
+
+export default linearPlugin;

--- a/packages/plugin-linear/tsconfig.json
+++ b/packages/plugin-linear/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@todone/internal-build/tsconfig",
+  "include": ["src/**/*", "types/**/*"]
+}

--- a/packages/plugin-linear/tsdown.config.ts
+++ b/packages/plugin-linear/tsdown.config.ts
@@ -1,0 +1,3 @@
+import { defaultConfig } from "@todone/internal-build/tsdown";
+
+export default defaultConfig();

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -24,6 +24,7 @@
     "@todone/plugin-date": "workspace:^",
     "@todone/plugin-figma": "workspace:^",
     "@todone/plugin-github": "workspace:^",
+    "@todone/plugin-linear": "workspace:^",
     "@types/node": "^24.13.2",
     "todone": "workspace:^"
   },

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -14,6 +14,7 @@
     "packages/plugin-date": {},
     "packages/plugin-figma": {},
     "packages/plugin-github": {},
+    "packages/plugin-linear": {},
     "packages/todone": {}
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -852,6 +852,21 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@todone/plugin-linear@workspace:^, @todone/plugin-linear@workspace:packages/plugin-linear":
+  version: 0.0.0-use.local
+  resolution: "@todone/plugin-linear@workspace:packages/plugin-linear"
+  dependencies:
+    "@todone/internal-build": "workspace:^"
+    "@types/node": "npm:^24.13.2"
+    todone: "workspace:^"
+    tsdown: "npm:^0.22.3"
+    typescript: "npm:~6.0.3"
+    zod: "npm:^4.4.3"
+  peerDependencies:
+    todone: "workspace:^"
+  languageName: unknown
+  linkType: soft
+
 "@todone/repo@workspace:.":
   version: 0.0.0-use.local
   resolution: "@todone/repo@workspace:."
@@ -882,6 +897,7 @@ __metadata:
     "@todone/plugin-date": "workspace:^"
     "@todone/plugin-figma": "workspace:^"
     "@todone/plugin-github": "workspace:^"
+    "@todone/plugin-linear": "workspace:^"
     "@types/node": "npm:^24.13.2"
     todone: "workspace:^"
   languageName: unknown


### PR DESCRIPTION
## Summary
This PR introduces a new Linear plugin for todone that allows users to track Linear issues in their TODO comments and automatically mark them as expired when the issue is completed or canceled.

## Key Changes
- **New `@todone/plugin-linear` package** with full Linear API integration
  - `api.ts`: GraphQL client for querying Linear issue status with Zod schema validation
  - `index.ts`: Plugin implementation that matches Linear issue URLs and checks their completion status
  - Supports both UUID and human-readable issue identifiers (e.g., `ENG-123`)
  
- **Configuration & Documentation**
  - Package metadata and build configuration (tsconfig, tsdown config)
  - Comprehensive documentation explaining setup, options, and usage
  - API key configuration via `apiKey` option or `LINEAR_API_KEY` environment variable

- **Integration**
  - Added plugin to test app dependencies
  - Updated release-please configuration for new package

## Notable Implementation Details
- Uses `URLPattern` API to parse Linear issue URLs with regex-based issue ID validation
- Implements proper error handling for API failures and missing issues
- Emits a warning if no API key is provided at plugin creation time
- Marks TODOs as expired when Linear issue state is `completed` or `canceled`
- Includes expiration date from either `completedAt` or `canceledAt` timestamps
- Full TypeScript support with Zod schema validation for API responses

https://claude.ai/code/session_01B2Rjb8Uo9RwxoxKaCN3rWJ