### PR TITLE
feat(plugin-date): support ISO 8601 date format in addition to datetime

### DIFF
--- a/packages/plugin-date/docs.md
+++ b/packages/plugin-date/docs.md
@@ -27,3 +27,5 @@ const foo = () => newImplementation();
 /** @deprecated */
 const deprecatedFoo = () => oldImplementation();
 ```
+
+You can also pass a full ISO 8601 datetime, like `date:2023-10-01T09:30:00Z`.

--- a/packages/plugin-date/src/index.ts
+++ b/packages/plugin-date/src/index.ts
@@ -8,15 +8,19 @@ const pattern = new URLPattern({
   pathname: ":date",
 });
 
-const isoDatetimeToDate = z.codec(z.iso.datetime(), z.date(), {
-  decode: (isoString) => new Date(isoString),
-  encode: (date) => date.toISOString(),
-});
+const isoToDate = z.codec(
+  z.union([z.iso.datetime(), z.iso.date()]),
+  z.date(),
+  {
+    decode: (isoString) => new Date(isoString),
+    encode: (date) => date.toISOString(),
+  },
+);
 
 const PatternResult = z.object({
   pathname: z.object({
     groups: z.object({
-      date: isoDatetimeToDate,
+      date: isoToDate,
     }),
   }),
 });


### PR DESCRIPTION
## Summary
Extended the date plugin to accept both ISO 8601 date and datetime formats, providing more flexibility for date input.

## Key Changes
- Renamed `isoDatetimeToDate` codec to `isoToDate` to better reflect its expanded functionality
- Updated the codec to accept a union of `z.iso.datetime()` and `z.iso.date()` instead of only datetime
- Updated the `PatternResult` schema to use the renamed codec
- Added documentation noting that full ISO 8601 datetime strings (e.g., `date:2023-10-01T09:30:00Z`) are now supported

## Implementation Details
The codec now uses `z.union([z.iso.datetime(), z.iso.date()])` as its input schema, allowing it to parse both date-only strings (e.g., `2023-10-01`) and full datetime strings (e.g., `2023-10-01T09:30:00Z`). The encoding behavior remains unchanged, converting dates to ISO string format via `toISOString()`.

https://claude.ai/code/session_015D2T34DJ6YJbwEWSPvY4Tg