### PR TITLE
fix!: move unhandledUrls option from config to CLI reporter

### DIFF
--- a/packages/test-app/todone.config.ts
+++ b/packages/test-app/todone.config.ts
@@ -5,6 +5,5 @@ import { defineConfig } from "todone/config";
 
 export default defineConfig({
   globs: ["./input/**/*"],
-  unhandledUrls: "warn",
   plugins: [githubPlugin()],
 });

--- a/packages/todone/docs.md
+++ b/packages/todone/docs.md
@@ -65,7 +65,7 @@ Analysis complete:
 1 expired results found
 ```
 
-`todone run` (the default command) prints human-readable output; `--only-expired` hides results that haven't expired yet, and `--locale` controls how dates are formatted. Use `todone run --json` instead to emit NDJSON (one JSON object per line) for machine consumption, or `todone run --check` to print nothing and exit with code 1 when any TODO is expired.
+`todone run` (the default command) prints human-readable output; `--only-expired` hides results that haven't expired yet, `--locale` controls how dates are formatted, and `--unhandled-urls` controls what happens when no plugin handles a URL (`error`, the default, `warn`, or `ignore`). Use `todone run --json` instead to emit NDJSON (one JSON object per line) for machine consumption, or `todone run --check` to print nothing and exit with code 1 when any TODO is expired.
 
 You can check more options by running `npx todone --help`.
 
@@ -80,9 +80,6 @@ import { defineConfig } from "todone/config";
 
 export default defineConfig({
   plugins: [caniusePlugin(), githubPlugin()],
-
-  // Optional: what to do when no plugin handles a URL: "error" (default), "warn", or "ignore".
-  unhandledUrls: "error",
 });
 ```
 

--- a/packages/todone/package.json
+++ b/packages/todone/package.json
@@ -61,7 +61,7 @@
     "dedent": "^1.7.2",
     "globby": "^16.2.0",
     "jiti": "^2.7.0",
-    "typanion": "^3.8.0",
+    "typanion": "^3.14.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/packages/todone/package.json
+++ b/packages/todone/package.json
@@ -61,6 +61,7 @@
     "dedent": "^1.7.2",
     "globby": "^16.2.0",
     "jiti": "^2.7.0",
+    "typanion": "^3.8.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/packages/todone/src/commands/run/impl.ts
+++ b/packages/todone/src/commands/run/impl.ts
@@ -3,11 +3,14 @@ import { loadConfigFile } from "#/lib/config/load";
 import { cliReporter } from "#/lib/reporters/cli";
 import { RunCommand } from "./index";
 
-export default async ({ onlyExpired, locale }: RunCommand) => {
+export default async ({ onlyExpired, locale, unhandledUrls }: RunCommand) => {
   const config = await loadConfigFile();
 
   await run({
     ...config,
-    plugins: [...config.plugins, cliReporter({ onlyExpired, locale })],
+    plugins: [
+      ...config.plugins,
+      cliReporter({ onlyExpired, locale, unhandledUrls }),
+    ],
   });
 };

--- a/packages/todone/src/commands/run/index.ts
+++ b/packages/todone/src/commands/run/index.ts
@@ -1,4 +1,5 @@
 import { Command, Option } from "clipanion";
+import * as t from "typanion";
 
 export class RunCommand extends Command {
   static paths = [Command.Default, ["run"]];
@@ -10,6 +11,10 @@ export class RunCommand extends Command {
     examples: [
       ["Run with human-readable output", "$0 run"],
       ["Only show expired TODOs", "$0 run --only-expired"],
+      [
+        "Warn instead of failing when no plugin handles a URL",
+        "$0 run --unhandled-urls warn",
+      ],
     ],
   });
 
@@ -19,6 +24,12 @@ export class RunCommand extends Command {
 
   locale = Option.String("--locale", {
     description: "Locale used to format dates; defaults to the system locale",
+  });
+
+  unhandledUrls = Option.String("--unhandled-urls", "error", {
+    description:
+      'What to do when no plugin returns a result for a URL: "error" (default), "warn", or "ignore"',
+    validator: t.isEnum(["error", "warn", "ignore"] as const),
   });
 
   execute = async () => (await import("./impl")).default(this);

--- a/packages/todone/src/index.ts
+++ b/packages/todone/src/index.ts
@@ -6,20 +6,6 @@ import { getFiles } from "./lib/files";
 import type { Plugin } from "./plugin";
 import type * as t from "./types";
 
-class UnhandledUrlError extends Error {
-  constructor(match: t.Match) {
-    const {
-      url,
-      file,
-      position: { line, column },
-    } = match;
-    super(
-      `No plugin returned a result for ${url} (${file.localPath}:${line}:${column}). ` +
-        `Add a plugin that handles this URL, or set \`unhandledUrls: "warn"\` or \`"ignore"\` in your todone config.`,
-    );
-  }
-}
-
 export interface RunOptions {
   /**
    * If set, all reporting goes to this plugin instead of the configured ones.
@@ -30,7 +16,7 @@ export interface RunOptions {
 }
 
 export const run = async (
-  { globs, gitignore, keyword, plugins, unhandledUrls }: Config,
+  { globs, gitignore, keyword, plugins }: Config,
   { forcedReporter }: RunOptions = {},
 ) => {
   await using container = new PluginContainer(plugins);
@@ -40,27 +26,11 @@ export const run = async (
 
   const reporter = forcedReporterContainer ?? container;
 
-  const check = async (match: t.Match): Promise<t.Result> => {
-    const result = await container.checkMatch({ url: match.url });
-
-    if (result === null) {
-      switch (unhandledUrls) {
-        case "error":
-          throw new UnhandledUrlError(match);
-        case "warn":
-          await reporter.warn(
-            `no plugin handled ${match.url} (${match.file.localPath}:${match.position.line}:${match.position.column})`,
-          );
-        // fallthrough
-        case "ignore":
-          break;
-        default:
-          return unhandledUrls satisfies never;
-      }
-    }
-
-    return { url: match.url, match, result };
-  };
+  const check = async (match: t.Match): Promise<t.Result> => ({
+    url: match.url,
+    match,
+    result: await container.checkMatch({ url: match.url }),
+  });
 
   const results = await it
     .from(getFiles(globs, { cwd: process.cwd(), gitignore: gitignore }))

--- a/packages/todone/src/index.ts
+++ b/packages/todone/src/index.ts
@@ -4,7 +4,6 @@ import { PluginContainer } from "./lib/core/container";
 import { makeFileMatcher } from "./lib/core/matcher";
 import { getFiles } from "./lib/files";
 import type { Plugin } from "./plugin";
-import type * as t from "./types";
 
 export interface RunOptions {
   /**
@@ -26,12 +25,6 @@ export const run = async (
 
   const reporter = forcedReporterContainer ?? container;
 
-  const check = async (match: t.Match): Promise<t.Result> => ({
-    url: match.url,
-    match,
-    result: await container.checkMatch({ url: match.url }),
-  });
-
   const results = await it
     .from(getFiles(globs, { cwd: process.cwd(), gitignore: gitignore }))
     .pipe(it.tap(reporter.reportFile))
@@ -39,7 +32,7 @@ export const run = async (
     .pipe(it.flatMap(makeFileMatcher(keyword)))
     .pipe(it.tap(reporter.reportMatch))
 
-    .pipe(it.map(check))
+    .pipe(it.map(container.check))
     .pipe(it.tap(reporter.reportResult))
 
     .sink(it.toArray());

--- a/packages/todone/src/index.ts
+++ b/packages/todone/src/index.ts
@@ -32,7 +32,7 @@ export const run = async (
     .pipe(it.flatMap(makeFileMatcher(keyword)))
     .pipe(it.tap(reporter.reportMatch))
 
-    .pipe(it.map(container.check))
+    .pipe(it.map(container.checkMatch))
     .pipe(it.tap(reporter.reportResult))
 
     .sink(it.toArray());

--- a/packages/todone/src/lib/config/schema.ts
+++ b/packages/todone/src/lib/config/schema.ts
@@ -3,12 +3,6 @@ import type { Plugin } from "../plugins";
 
 const PluginSchema = z.custom<Plugin>();
 
-export type UnhandledUrls = z.infer<typeof UnhandledUrlsSchema>;
-
-const UnhandledUrlsSchema = z
-  .enum(["ignore", "warn", "error"])
-  .prefault("error");
-
 export interface Config extends z.infer<typeof ConfigSchema> {}
 export interface ConfigInput extends z.input<typeof ConfigSchema> {}
 
@@ -21,9 +15,6 @@ export const ConfigSchema = z.object({
 
   /** The file patterns to include. */
   globs: z.array(z.string()).prefault(["**/*"]),
-
-  /** What to do when no plugin returns a result for a URL. */
-  unhandledUrls: UnhandledUrlsSchema,
 
   /** The plugins to run. */
   plugins: z.array(PluginSchema).prefault([]),

--- a/packages/todone/src/lib/core/container.ts
+++ b/packages/todone/src/lib/core/container.ts
@@ -1,4 +1,5 @@
 import type { CheckerResult, Plugin } from "#/plugin";
+import type * as t from "#/types";
 
 export class PluginError extends Error {
   constructor(pluginName: string, url: URL, cause: unknown) {
@@ -83,6 +84,16 @@ export class PluginContainer implements Required<Plugin> {
           );
       } else throw error;
     });
+
+  /**
+   * Check a {@link t.Match} against all plugins and bundle the outcome as a
+   * {@link t.Result}.
+   */
+  readonly check = async (match: t.Match): Promise<t.Result> => ({
+    url: match.url,
+    match,
+    result: await this.checkMatch({ url: match.url }),
+  });
 
   async [Symbol.asyncDispose]() {
     await Promise.all(

--- a/packages/todone/src/lib/core/container.ts
+++ b/packages/todone/src/lib/core/container.ts
@@ -1,4 +1,4 @@
-import type { CheckerResult, Plugin } from "#/plugin";
+import type { Plugin } from "#/plugin";
 import type * as t from "#/types";
 
 export class PluginError extends Error {
@@ -12,13 +12,15 @@ type FanOutHook =
 
 /**
  * Holds all the plugins for a run and knows how to dispatch each hook to
- * them: {@link Plugin.checkMatch} races all checkers and settles on the first
- * one to recognize the URL, while the reporting hooks and disposal fan out to
- * every plugin implementing them.
+ * them: {@link PluginContainer.checkMatch} races all checkers and settles on
+ * the first one to recognize the URL, while the reporting hooks and disposal
+ * fan out to every plugin implementing them.
  *
- * Each hook mirrors the name and signature of its {@link Plugin} counterpart.
+ * The reporting hooks mirror the name and signature of their {@link Plugin}
+ * counterparts; `checkMatch` instead takes a whole {@link t.Match} and
+ * bundles the outcome as a {@link t.Result}.
  */
-export class PluginContainer implements Required<Plugin> {
+export class PluginContainer implements Required<Omit<Plugin, "checkMatch">> {
   /** Thrown internally when a plugin didn't recognize a URL. */
   static readonly #UNHANDLED = Symbol("unhandled");
 
@@ -51,12 +53,10 @@ export class PluginContainer implements Required<Plugin> {
   readonly reportMatch = this.#fanOut("reportMatch");
   readonly reportResult = this.#fanOut("reportResult");
 
-  readonly checkMatch = async ({
-    url,
-  }: {
-    url: URL;
-  }): Promise<CheckerResult | null> =>
-    await Promise.any(
+  readonly checkMatch = async (match: t.Match): Promise<t.Result> => {
+    const { url } = match;
+
+    const result = await Promise.any(
       this.#plugins
         .map((plugin) =>
           plugin.checkMatch?.({ url }).then(
@@ -85,15 +85,8 @@ export class PluginContainer implements Required<Plugin> {
       } else throw error;
     });
 
-  /**
-   * Check a {@link t.Match} against all plugins and bundle the outcome as a
-   * {@link t.Result}.
-   */
-  readonly check = async (match: t.Match): Promise<t.Result> => ({
-    url: match.url,
-    match,
-    result: await this.checkMatch({ url: match.url }),
-  });
+    return { url, match, result };
+  };
 
   async [Symbol.asyncDispose]() {
     await Promise.all(

--- a/packages/todone/src/lib/reporters/cli.ts
+++ b/packages/todone/src/lib/reporters/cli.ts
@@ -1,17 +1,37 @@
 import type { Plugin } from "#/plugin";
+import type * as t from "#/types";
 import chalk from "chalk";
 import dedent from "dedent";
+
+export type UnhandledUrls = "ignore" | "warn" | "error";
+
+class UnhandledUrlError extends Error {
+  constructor(match: t.Match) {
+    const {
+      url,
+      file,
+      position: { line, column },
+    } = match;
+    super(
+      `No plugin returned a result for ${url} (${file.localPath}:${line}:${column}). ` +
+        `Add a plugin that handles this URL, or pass \`--unhandled-urls warn\` or \`--unhandled-urls ignore\`.`,
+    );
+  }
+}
 
 export interface CliReporterOptions {
   /** The locale to format dates with. Defaults to the system locale. */
   locale?: string;
   /** Only print expired results. */
   onlyExpired?: boolean;
+  /** What to do when no plugin returns a result for a URL. */
+  unhandledUrls?: UnhandledUrls;
 }
 
 export const cliReporter = ({
   locale,
   onlyExpired = false,
+  unhandledUrls = "error",
 }: CliReporterOptions = {}): Plugin => {
   const dateFormatter = new Intl.DateTimeFormat(locale);
 
@@ -38,15 +58,27 @@ export const cliReporter = ({
       matchesCounter++;
     },
 
-    reportResult: async ({
-      url,
-      result,
-      match: {
+    reportResult: async ({ url, result, match }) => {
+      const {
         file,
         position: { line, column },
-      },
-    }) => {
-      if (result === null) return;
+      } = match;
+
+      if (result === null) {
+        switch (unhandledUrls) {
+          case "error":
+            throw new UnhandledUrlError(match);
+          case "warn":
+            console.warn(
+              `no plugin handled ${url} (${file.localPath}:${line}:${column})`,
+            );
+          // fallthrough
+          case "ignore":
+            return;
+          default:
+            return unhandledUrls satisfies never;
+        }
+      }
 
       resultsCounter++;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2937,6 +2937,7 @@ __metadata:
     globby: "npm:^16.2.0"
     jiti: "npm:^2.7.0"
     tsdown: "npm:^0.22.3"
+    typanion: "npm:^3.8.0"
     type-fest: "npm:^5.8.0"
     typescript: "npm:~6.0.3"
     zod: "npm:^4.4.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2937,7 +2937,7 @@ __metadata:
     globby: "npm:^16.2.0"
     jiti: "npm:^2.7.0"
     tsdown: "npm:^0.22.3"
-    typanion: "npm:^3.8.0"
+    typanion: "npm:^3.14.0"
     type-fest: "npm:^5.8.0"
     typescript: "npm:~6.0.3"
     zod: "npm:^4.4.3"
@@ -3027,10 +3027,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typanion@npm:^3.8.0":
-  version: 3.12.1
-  resolution: "typanion@npm:3.12.1"
-  checksum: 10/abd4cd4d4c91dfe548639f17e01581ec3a0be4c3b348c41f73a4b510729102a4028b0040163dffecfaefeb13eeb6b15cc018a69e44d49926b859eba6dfaf24bb
+"typanion@npm:^3.14.0, typanion@npm:^3.8.0":
+  version: 3.14.0
+  resolution: "typanion@npm:3.14.0"
+  checksum: 10/5e88d9e6121ff0ec543f572152fdd1b70e9cca35406d79013ec8e08defa8ef96de5fec9e98da3afbd1eb4426b9e8e8fe423163d0b482e34a40103cab1ef29abd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
This PR refactors the `unhandledUrls` configuration option from a global config setting to a CLI-specific reporter option. This change makes the option more flexible by allowing it to be controlled via CLI flags while removing it from the configuration file schema.

## Key Changes
- **Moved `UnhandledUrlError` class** from `src/index.ts` to `src/lib/reporters/cli.ts` where it's actually used
- **Removed `unhandledUrls` from global config schema** (`src/lib/config/schema.ts`) - it's no longer a configuration file option
- **Added `unhandledUrls` as a CLI option** (`src/commands/run/index.ts`) with validation using typanion, allowing users to pass `--unhandled-urls error|warn|ignore` on the command line
- **Updated CLI reporter** to accept and handle the `unhandledUrls` option, implementing the error/warn/ignore logic directly in the reporter's `reportResult` method
- **Simplified core run logic** (`src/index.ts`) by removing the unhandled URL handling from the main check function - this responsibility now belongs to the reporter
- **Updated documentation and examples** to reflect the new CLI-based approach
- **Added typanion dependency** for CLI option validation

## Implementation Details
- The `unhandledUrls` option now defaults to `"error"` at the CLI level
- The error message was updated to reference CLI flags (`--unhandled-urls warn`) instead of config file options
- The logic flow is cleaner: the core runner simply returns null results, and the reporter decides how to handle them based on the configured option
- This makes the behavior more composable - different reporters could handle unhandled URLs differently if needed

https://claude.ai/code/session_01RWpZYJF1fU1HTzs5vm61F7